### PR TITLE
APIMF-2614: Rework related documentation for open-sourcing

### DIFF
--- a/docs/code/parsing.mdx
+++ b/docs/code/parsing.mdx
@@ -30,7 +30,6 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CodeGetter from "../../components/CodeGetter";
 
-<!-- the code tabs should have exactly this indentation -->
 <Tabs
     groupId="languages"
     defaultValue="java"

--- a/docs/related/amf-conversion.mdx
+++ b/docs/related/amf-conversion.mdx
@@ -1,9 +1,193 @@
 ---
 id: amf_conversion
 title: AMF Conversion
-hide_title: true
 ---
 
-# AMF Conversion
+:::caution
+The behaviour expressed in this documentation is currently a work in progress.
+If any bugs are found that do not satisfy these requirements,
+please file an issue in the [aml-org/amf repository](https://github.com/aml-org/amf/pull/715).
+:::
+
+# What is WebAPIs conversion?
+
+Conversion stands for the capability of parsing an API from one specification vendor into an API graph and then rendering said graph as a different vendor’s specification.
+
+Different specifications can have different required fields, and the same information conceptually may not be described in the same way.
+This is the reason why in a *cross parsing-rendering process*, the AMF graph needs to go through a transformation called *“Compatibility resolution”*.
+
+**Compatibility resolution** is a specific resolution pipeline that is used to adapt an API graph parsed from spec A, to fulfill the requirements of the spec in which it will be rendered.
+An example of how to use Compatibility Resolution can be seen in [Example 1](#conversion-examples).
 
 
+How does this impact the API model? For example, fields that are not required in the origin spec but required in the target spec,
+will be added with default values if they are not present in the origin spec.
+
+:::tip The Objective
+The objective of conversion is to **output a valid AMF model for the spec in which it will be rendered**.
+It aims to **keep information loss to a minimum through a best-effort process** with some limitations.
+:::
+
+
+## Conversion Goals
+
+Conversion resolution has several goals:
+- Make transitioning to/from OAS to RAML easier for the end user.
+- Give the user an approximate view of what his API in another spec would look like
+- Let tools use specs that they don’t directly support
+- Take advantage of spec-specific tooling
+    - for example, converting to OAS to use swagger-ui in a microservice or using a trusted client-spec generator that only works with RAML.
+
+
+
+# Conversion limitations
+The AMF team, having listened to other team’s needs, is the one that dictates how the model is adapted to fit other specs:
+- If there is 1:1 information type mapping between specs it will be converted.
+- If there are missing mandatory fields default value will be added. The default’s value is opinionated.
+- Anything else is omitted.
+
+
+### Concepts present in a spec but nonexistent in another aren’t supported
+Sometimes a spec may introduce concepts that don’t exist in other specs. There are many cases coming from Raml to Oas, some are:
+- Datatype Fragments
+- Libraries
+- Resource Types and Traits
+- Overlays and Extensions
+
+These document types and objects cannot be converted to Oas as these constructs do not exist in that spec.
+These constructs can be migrated to Oas if and only if they are referenced from a root Api document.
+
+
+### Not all specs are supported
+
+This is a direct consequence of the previous limitation, not all specs can be converted between each other. Currently, Async API is not supported for conversion.
+It’s event-led concepts don’t have a direct correspondence to REST concepts described in RAML or OAS.
+For example, how would an Async APIs “subscribe” or “binding” be in RAML? The amount of similar concepts is simply not enough to create similar graphs.
+Supported conversions are:
+- RAML 1.0 to OAS 2.0 and vice-versa
+- RAML 1.0 to OAS 3.0 and vice-versa
+
+
+### Information may be lost
+Original information that is incompatible with the target spec may be lost. This is also a consequence of the first limitation.
+For example OAS 3 links have no way of being migrated into RAML and will not be rendered in the converted RAML spec.
+
+In the next example, not all of the RAML  `documentation` nodes can be migrated to OAS 3.0 `externalDocs` nodes.
+In fact, only the first `documentation` node is kept while the others are lost.
+As the RAML 1.0 `documentation` does not define an url like OAS 3.0’s does, an url node is defined with an “empty” url.
+
+
+
+```yaml title="RAML to OAS 3.0 documentation conversion example - RAML code"
+documentation:
+    - title: Test Console and Mocking Service
+    content: |
+        Welcome to the \_Test API\_ Documentation. The \_Test API\_
+        allows you to test console and mocking service features
+        [integration libraries](https://mulesoft.com)
+    - title: Legal
+    content: !include docs/api.md
+```
+
+```yaml title="RAML to OAS 3.0 documentation conversion example - OAS code"
+externalDocs:
+    url: http://
+    description: |
+        Welcome to the \_Test API\_ Documentation. The \_Test API\_
+        allows you to test console and mocking service features
+        [integration libraries](https://mulesoft.com)
+```
+
+### Conversion is not customizable
+
+Default conversion resolution is not customizable as each spec conversion is implemented as a *ResolutionPipeline* and currently pipelines are not modifiable.
+We know and understand that the same API can be modeled in different ways following different practices, but it's not possible to cover them all.
+
+A different conversion resolution can be implemented by creating a new *ResolutionPipeline* with the required conversion stages.
+
+
+### Round-trip conversions
+
+When AMF adapts a model graph to be able to render it in another spec, it knows from which spec the model was parsed (spec A) and to which spec the model will be rendered (spec B).
+After the model is rendered that knowledge is lost as that file is just another API from spec B.
+This context loss makes it impossible to convert back again from spec B to spec A and expect exactly the same content.
+
+Previously, AMF attempted to reduce this information lost in conversion by rendering constructs that could only be parsed by them.
+This was often done with special API constructs given by the specs and recognized by AMF:
+- [*annotations*](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#annotations) in RAML, written as `amf-.*`.
+- [*specification extensions*](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#specification-extensions) in OpenApi, written as `x-amf-.*`.
+
+These attempts to keep as much information possible have two main drawbacks:
+- AMF can’t know whether some content in the rendered spec, like annotations, was rendered for compatibility purposes, or it is something that a spec author wanted to have in the spec.
+- All recognizable attributes that AMF can write in the spec to identify it as coming from a compatibility context can be emulated by a spec designer with a modeling intention and are therefore invalid as conversion identifiers.
+
+
+# Common Questions
+
+### Why don’t we use annotations to render incompatible content?
+Incompatible content isn’t rendered in an annotation because it goes against one of the goals of conversion: take advantage of tooling in a specific spec.
+Annotation-rendered incompatible content will not be processed by tooling with the intent it was added to the spec, thus rendering that content useless.
+
+### Why have some items in the spec lost their relative order?
+AMF doesn’t guarantee that items keep their relative order. The framework does a best-effort of keeping order by reusing the spec’s lexical information.
+API resolution may sometimes make that lexical information useless or meaningless due to several operations that it performs.
+This is significant especially in conversion where fields may be added, removed or transformed.
+
+Why doesn’t AMF guarantee relative order? AMF’s underlying model is a directed cyclic graph.
+In a graph, outgoing edges from a vertex aren’t ordered relatively as the only thing that matters is where those edges go, not how they are ordered. The same applies to AMF’s model.
+
+### Can I parse and render my API from a spec to the same one?
+You shouldn’t resolve the model with a compatibility pipeline as these pipelines are just to move between different specifications.
+
+To render to the same specification you shouldn’t apply a resolution unless you want the model to also be resolved (apply traits, resource types, apply inheritance and links, solve parameters, etc).
+
+Although you can cycle (parse and render) your API using AMF you should reconsider why you are doing it and see if the framework has the capabilities of achieving what you seek in a different, more useful way.
+
+### Why do I have to use conversion resolution? Can’t Renderers know how to render correctly?
+Rendering has to render any model that is passed to the Renderers, it can’t modify said model.
+This is why conversion is done in a resolution stage (using a specific pipeline for compatibility), it is the only place where the model can be transformed before rendering.
+
+
+# Conversion Examples
+```java title="Example 1. Conversion from RAML 1.0 to OAS 2.0 (Java)"
+AMF.init().get();
+BaseUnit ramlApi = new RamlParser().parseFileAsync("<your-converted-api-file-path>").get();
+Resolver resolver = new Oas20Resolver();
+BaseUnit convertedOasApi = resolver.resolve(ramlApi, ResolutionPipeline.COMPATIBILITY_PIPELINE());
+Renderer renderer = new Oas20Renderer();
+renderer.generateFile(convertedOasApi, "<your-converted-api-file-path>").get();
+```
+
+```java title="Example 2. Custom ResolutionPipeline creation (Java)"
+class MyOas20ConversionPipeline extends ResolutionPipeline {
+  public MyOas20ConversionPipeline(ErrorHandler eh) {
+    super(eh);
+  }
+
+  @Override
+  public ProfileName profileName() {
+    return Oas20Profile$.MODULE$;
+  }
+
+
+  @Override
+  public Seq<ResolutionStage> steps() {
+    List<ResolutionStage> stages = new ArrayList<>();
+    stages.add(new MyCustomStage(this.eh()));
+    return JavaConverters.asScalaBuffer(stages);
+  }
+}
+
+public class MyCustomStage extends ResolutionStage {
+
+    public MyCustomStage(ErrorHandler errorHandler) {
+        super(errorHandler);
+    }
+
+    @Override
+    public <T extends BaseUnit> T resolve(T model) {
+        return model;
+    }
+}
+
+```

--- a/docs/related/amf-conversion.mdx
+++ b/docs/related/amf-conversion.mdx
@@ -4,19 +4,20 @@ title: AMF Conversion
 ---
 
 :::caution
-The behaviour expressed in this documentation is currently a work in progress.
-If any bugs are found that do not satisfy these requirements,
-please file an issue in the [aml-org/amf repository](https://github.com/aml-org/amf/pull/715).
+The functionality expressed in this documentation is currently a work in progress.
+If any bugs are found that do not satisfy these functionalities,
+please file an issue in the [amf repository](https://github.com/aml-org/amf/issues).
 :::
 
 # What is WebAPIs conversion?
-
-Conversion stands for the capability of parsing an API from one specification vendor into an API graph and then rendering said graph as a different vendor’s specification.
+Conversion stands for the capability of parsing a [**WebAPI**](https://github.com/aml-org/amf/blob/develop/documentation/model.md#webapi) from one specification vendor into an API graph and then rendering said graph as a different vendor's specification.
+It's a *cross parsing-rendering process* from a source spec to a different target spec.
 
 Different specifications can have different required fields, and the same information conceptually may not be described in the same way.
-This is the reason why in a *cross parsing-rendering process*, the AMF graph needs to go through a transformation called *“Compatibility resolution”*.
+This is why the AMF graph needs to go through a transformation process called *“Compatibility resolution”*.
 
-**Compatibility resolution** is a specific resolution pipeline that is used to adapt an API graph parsed from spec A, to fulfill the requirements of the spec in which it will be rendered.
+[**Compatibility resolution**](../AMF/using-amf/resolution.mdx#pipelines) is a specific resolution pipeline that is used to adapt an API graph parsed from one spec (source),
+to fulfill the requirements of another spec in which it will be rendered (target).
 An example of how to use Compatibility Resolution can be seen in [Example 1](#conversion-examples).
 
 
@@ -30,51 +31,52 @@ It aims to **keep information loss to a minimum through a best-effort process** 
 
 
 ## Conversion Goals
-
 Conversion resolution has several goals:
-- Make transitioning to/from OAS to RAML easier for the end user.
-- Give the user an approximate view of what his API in another spec would look like
-- Let tools use specs that they don’t directly support
+- Make transitioning to/from OAS to RAML easier for the end user
+- Give the user an approximate view of what their API in another spec would look like
+- Let tools use specs that they don't directly support
 - Take advantage of spec-specific tooling
-    - for example, converting to OAS to use swagger-ui in a microservice or using a trusted client-spec generator that only works with RAML.
+    - for example, converting to OAS to use [swagger-ui](https://swagger.io/tools/swagger-ui) in a microservice or using a trusted client-spec generator that only works with RAML
 
 
 
 # Conversion limitations
-The AMF team, having listened to other team’s needs, is the one that dictates how the model is adapted to fit other specs:
-- If there is 1:1 information type mapping between specs it will be converted.
-- If there are missing mandatory fields default value will be added. The default’s value is opinionated.
-- Anything else is omitted.
+The AMF team, having listened to other team's needs, is the one that dictates how the model is adapted to fit other specs:
+- If there is 1:1 information type mapping between specs it will be converted
+- If there are missing mandatory fields, a default value will be added
+  The default's value is opinionated, meaning that there may be more than one possible value, and we choose which one we use
+- Anything else is omitted
 
 
-### Concepts present in a spec but nonexistent in another aren’t supported
-Sometimes a spec may introduce concepts that don’t exist in other specs. There are many cases coming from Raml to Oas, some are:
+### Concepts present in a spec but nonexistent in another aren't supported
+Sometimes a spec may introduce concepts that don't exist in other specs. There are many cases coming from RAML to OAS, some are:
 - Datatype Fragments
 - Libraries
 - Resource Types and Traits
 - Overlays and Extensions
 
-These document types and objects cannot be converted to Oas as these constructs do not exist in that spec.
-These constructs can be migrated to Oas if and only if they are referenced from a root Api document.
+These concepts cannot be converted to OAS as they do not exist in that spec.
+These constructs can be migrated to OAS if and only if they are referenced from a root Api document.
 
 
 ### Not all specs are supported
+As a consequence of the previous limitation, not all specs can be converted between each other. Currently, Async API is not supported for conversion.
+Its event-led concepts don't have a direct correspondence to REST concepts described in RAML or OAS.
+For example, how would an Async APIs `subscribe` or `binding` be in RAML? The amount of similar concepts is simply not enough to create similar graphs.
 
-This is a direct consequence of the previous limitation, not all specs can be converted between each other. Currently, Async API is not supported for conversion.
-It’s event-led concepts don’t have a direct correspondence to REST concepts described in RAML or OAS.
-For example, how would an Async APIs “subscribe” or “binding” be in RAML? The amount of similar concepts is simply not enough to create similar graphs.
 Supported conversions are:
 - RAML 1.0 to OAS 2.0 and vice-versa
 - RAML 1.0 to OAS 3.0 and vice-versa
 
 
 ### Information may be lost
-Original information that is incompatible with the target spec may be lost. This is also a consequence of the first limitation.
+Original information that is incompatible with the target spec may be lost.
+This is also a consequence of having concepts present in source spec that don't exist in the target spec.
 For example OAS 3 links have no way of being migrated into RAML and will not be rendered in the converted RAML spec.
 
-In the next example, not all of the RAML  `documentation` nodes can be migrated to OAS 3.0 `externalDocs` nodes.
+In the next example, not all the RAML  `documentation` nodes can be migrated to OAS 3.0 `externalDocs` nodes.
 In fact, only the first `documentation` node is kept while the others are lost.
-As the RAML 1.0 `documentation` does not define an url like OAS 3.0’s does, an url node is defined with an “empty” url.
+As the RAML 1.0 `documentation` does not define an url like OAS 3.0's does, an url node is defined with an “empty” url.
 
 
 
@@ -98,12 +100,12 @@ externalDocs:
         [integration libraries](https://mulesoft.com)
 ```
 
-### Conversion is not customizable
+### Default conversion is not customizable
+Each spec conversion is implemented as a different [*Resolution Pipeline*](../AMF/using-amf/resolution.mdx), and provided pipelines are not modifiable.
+Thus, the provided default conversion functionality is not customizable.
+However, a different conversion resolution can be implemented by creating a new *ResolutionPipeline* with the required conversion stages.
 
-Default conversion resolution is not customizable as each spec conversion is implemented as a *ResolutionPipeline* and currently pipelines are not modifiable.
-We know and understand that the same API can be modeled in different ways following different practices, but it's not possible to cover them all.
-
-A different conversion resolution can be implemented by creating a new *ResolutionPipeline* with the required conversion stages.
+We know and understand that the same API can be modeled and emitted in different ways following different practices, but it's not possible to cover them all.
 
 
 ### Round-trip conversions
@@ -114,37 +116,37 @@ This context loss makes it impossible to convert back again from spec B to spec 
 
 Previously, AMF attempted to reduce this information lost in conversion by rendering constructs that could only be parsed by them.
 This was often done with special API constructs given by the specs and recognized by AMF:
-- [*annotations*](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#annotations) in RAML, written as `amf-.*`.
-- [*specification extensions*](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#specification-extensions) in OpenApi, written as `x-amf-.*`.
+- [*annotations*](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#annotations) in RAML, written as `amf-.*`
+- [*specification extensions*](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#specification-extensions) in OpenApi, written as `x-amf-.*`
 
 These attempts to keep as much information possible have two main drawbacks:
-- AMF can’t know whether some content in the rendered spec, like annotations, was rendered for compatibility purposes, or it is something that a spec author wanted to have in the spec.
-- All recognizable attributes that AMF can write in the spec to identify it as coming from a compatibility context can be emulated by a spec designer with a modeling intention and are therefore invalid as conversion identifiers.
+- AMF can't know whether some content in the rendered spec, like annotations, was rendered for compatibility purposes, or it is something that a spec author wanted to have in the spec
+- All recognizable attributes that AMF can write in the spec to identify it as coming from a compatibility context can be emulated by a spec designer with a modeling intention and are therefore invalid as conversion identifiers
 
 
 # Common Questions
 
-### Why don’t we use annotations to render incompatible content?
-Incompatible content isn’t rendered in an annotation because it goes against one of the goals of conversion: take advantage of tooling in a specific spec.
+### Why don't we use annotations to render incompatible content?
+Incompatible content isn't rendered in an annotation because it goes against one of the goals of conversion: take advantage of tooling in a specific spec.
 Annotation-rendered incompatible content will not be processed by tooling with the intent it was added to the spec, thus rendering that content useless.
 
 ### Why have some items in the spec lost their relative order?
-AMF doesn’t guarantee that items keep their relative order. The framework does a best-effort of keeping order by reusing the spec’s lexical information.
+AMF doesn't guarantee that items keep their relative order. The framework does a best-effort of keeping order by reusing the spec's lexical information.
 API resolution may sometimes make that lexical information useless or meaningless due to several operations that it performs.
 This is significant especially in conversion where fields may be added, removed or transformed.
 
-Why doesn’t AMF guarantee relative order? AMF’s underlying model is a directed cyclic graph.
-In a graph, outgoing edges from a vertex aren’t ordered relatively as the only thing that matters is where those edges go, not how they are ordered. The same applies to AMF’s model.
+Why doesn't AMF guarantee relative order? AMF's underlying model is a directed cyclic graph.
+In a graph, outgoing edges from a vertex aren't ordered relatively as the only thing that matters is where those edges go, not how they are ordered. The same applies to AMF's model.
 
 ### Can I parse and render my API from a spec to the same one?
-You shouldn’t resolve the model with a compatibility pipeline as these pipelines are just to move between different specifications.
+You shouldn't resolve the model with a compatibility pipeline as these pipelines are just to move between different specifications.
 
-To render to the same specification you shouldn’t apply a resolution unless you want the model to also be resolved (apply traits, resource types, apply inheritance and links, solve parameters, etc).
+To render to the same specification you shouldn't apply a resolution unless you want the model to also be resolved (apply traits, resource types, apply inheritance and links, solve parameters, etc).
 
 Although you can cycle (parse and render) your API using AMF you should reconsider why you are doing it and see if the framework has the capabilities of achieving what you seek in a different, more useful way.
 
-### Why do I have to use conversion resolution? Can’t Renderers know how to render correctly?
-Rendering has to render any model that is passed to the Renderers, it can’t modify said model.
+### Why do I have to use conversion resolution? Can't Renderers know how to render correctly?
+Rendering has to render any model that is passed to the Renderers, it can't modify said model.
 This is why conversion is done in a resolution stage (using a specific pipeline for compatibility), it is the only place where the model can be transformed before rendering.
 
 

--- a/docs/related/async-raml-datatypes.mdx
+++ b/docs/related/async-raml-datatypes.mdx
@@ -1,0 +1,324 @@
+---
+id: async_raml_datatypes
+title: Async + RAML Data Types in AMF
+---
+
+:::info Technical Document
+This is a technical document, this information is intended for experienced users
+:::
+
+Within the Async specification it is possible to use raml data types to define a payload, taking into account that the schema format is specified accordingly.
+Both specifications have their own distinct referencing and modularization mechanisms, and it is not clear where to draw the line to determine where one specification stops, and the other one starts.
+This document will describe how to use RAML types in Async when using AMF.
+
+
+## Referencing external RAML content using ‘$ref’
+In order to support referencing raml content in external files, AMF allows the use of the `$ref` mechanism present in Async but with clear restrictions.
+This enables referencing data type fragments, data types present in libraries, as well as any raml content present in yaml or json files.
+
+Given that the payload content must comply with RAML, **the ‘$ref’ may only be used at the root of the payload definition as an exception to this rule**.
+Its target content must be valid structurally according to the relevant RAML specification:
+
+export const myStyle = {
+    padding: "15px 5px",
+};
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="‘$ref’ at root of payload (Valid)"
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+  $ref: “...” # must reference raml content
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="‘$ref’ nested within raml content (Invalid)" {6}
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+ type: object
+ properties:
+   user:
+     $ref: “...” # '$ref' is not valid in RAML
+```
+
+</div>
+</div>
+</div>
+
+
+The following section shows all supported use cases when using this referencing mechanism, adding additional comments if necessary.
+
+
+
+### Reference to data type fragments
+The data type fragment must be self-contained, meaning it cannot depend on any definition made in the root api. The following example is **valid** for this use case.
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Async api"
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+ $ref: external-data-type.raml
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="RAML data type fragment (external-data-type.raml)"
+#%RAML 1.0 DataType
+
+type: object
+properties:
+  a: string | object
+```
+
+</div>
+</div>
+</div>
+
+The following referenced data type is **invalid** as it is not self-contained, meaning the data type fragment depends on type definitions which will not be resolved in the root api.
+Due to known limitations this api will not return validations, but the reference to the type Other will not be made.
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Async api"
+components:
+ schemas:
+   Other: ...
+channels:
+ users/signup:
+   subscribe:
+     message:
+       schemaFormat: application/raml+yaml;version=1.0
+       payload:
+        $ref: external-data-type.raml
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="RAML data type fragment (external-data-type.raml)" {5}
+#%RAML 1.0 DataType
+
+type: object
+properties:
+ a: Other
+```
+
+</div>
+</div>
+</div>
+
+
+Use of relative pointers to nested content within the data type fragment is not supported, like in the following **invalid** example:
+```yaml {3}
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+ $ref: external-data-type.raml#/properties/a
+```
+
+
+
+### Reference to types in library fragments
+For the case of libraries, type definitions can be referenced using the following fixed pointer: `{lib}#/types/{typeName}`.
+When referencing types defined in a library, the included content will have context of other type definitions present in the original library.
+This can be seen in the following **valid** example where the type User references another type present in the external library.
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Async api"
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+  $ref: ../external-library.raml#/types/User
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="RAML library fragment (external-library.raml)"
+#%RAML 1.0 Library
+
+types:
+ User:
+   type: Other | string
+
+ Other:
+   type: string
+```
+
+</div>
+</div>
+</div>
+
+**The external library must be self-contained**, meaning it cannot depend on types defined in the root api.
+In the following **invalid** example, the library depends on the definition of the type Other, which will not be resolved from the definitions present in the main api.
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Async api"
+components:
+ schemas:
+   Other: ...
+channels:
+ users/signup:
+   subscribe:
+     message:
+       schemaFormat: application/raml+yaml;version=1.0
+       payload:
+        $ref: ../external-library.raml#/types/User
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="RAML library fragment (external-library.raml)" {5}
+#%RAML 1.0 Library
+
+types:
+ User:
+   type: Other | string
+```
+
+</div>
+</div>
+</div>
+
+
+
+### Reference to external yaml/json files
+When referencing external yaml or json files, the `$ref` inlines the content.
+Relative json pointers can be used to reference content that is nested within the file, but taking into account the following limitation:
+
+:::caution When referencing to external yaml/json files
+the external file **must not** be a known RAML fragment or api specification.
+:::
+
+The following case is a **valid** reference making use of relative json pointers.
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Async api"
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+ $ref: external-yaml.yaml#/definitions/User
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Yaml file (external-yaml.yaml)"
+definitions:
+ User:
+   type: string | object
+```
+
+</div>
+</div>
+</div>
+
+As previously mentioned, when the target file is a known raml fragment or api specification free use of relative json pointers is not supported.
+The following example shows an **invalid** example when using relative json pointer to reference an external RAML specification:
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Async api"
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+ $ref: ../api.raml#/types/User
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="External RAML api (api.raml)" {1}
+#%RAML 1.0
+title: Instagram API
+
+types:
+ User:
+   type: object
+```
+
+</div>
+</div>
+</div>
+
+
+
+## Inlined RAML types
+The simplest way to define a raml type in Async is by defining your content inlined under the `payload` facet while using the appropriate schema format like so:
+```yaml
+schemaFormat: application/raml+yaml;version=1.0
+payload: # The following is a RAML data type
+ type: object
+ properties:
+   a: object | string
+ additionalProperties: false
+```
+**All content within the payload will be considered strictly RAML**, except when using ‘$ref’ at the root of the payload (see the [previous section](#referencing-external-raml-content-using-ref) for more details).
+
+
+### Isolated RAML context
+When defining inlined types, its context is fully restricted from the content defined outside the payload facet.
+This means that any reference to content defined in the `components` facet of the main Async api will not be resolved.
+
+```yaml title="Referencing types defined in async api components (invalid)" {10}
+components:
+ schemas:
+   User: ...
+channels:
+ users/signup:
+   subscribe:
+     message:
+       schemaFormat: application/raml+yaml;version=1.0
+       payload:
+         type: User #unresolved reference
+```
+
+
+### Limited RAML referencing mechanism
+RAML has its own referencing mechanism to include content from external files using a reserved yaml tag `!include`.
+**AMF will only support referencing external data type fragments when using this mechanism.** This feature will be limited to Async apis defined in yaml format, as json has no way of defining tags.
+As this syntax is valid within a RAML context, including data types fragments can be made at the root of the payload content, or nested within other inlined content:
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Using include at root of payload"
+schemaFormat: application/raml+yaml;version=1.0
+payload: !include external-data-type.raml
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```yaml title="Using include within inlined content"
+schemaFormat: application/raml+yaml;version=1.0
+payload:
+ type: object
+ properties:
+   id: string
+   user: !include external-data-type.raml
+```
+
+</div>
+</div>
+</div>
+

--- a/docs/related/async-raml-datatypes.mdx
+++ b/docs/related/async-raml-datatypes.mdx
@@ -7,16 +7,17 @@ title: Async + RAML Data Types in AMF
 This is a technical document, this information is intended for experienced users
 :::
 
-Within the Async specification it is possible to use raml data types to define a payload, taking into account that the schema format is specified accordingly.
+Within the Async specification it is possible to use RAML data types to define a payload, taking into account that the schema format is specified accordingly.
 Both specifications have their own distinct referencing and modularization mechanisms, and it is not clear where to draw the line to determine where one specification stops, and the other one starts.
 This document will describe how to use RAML types in Async when using AMF.
 
 
-## Referencing external RAML content using ‘$ref’
-In order to support referencing raml content in external files, AMF allows the use of the `$ref` mechanism present in Async but with clear restrictions.
-This enables referencing data type fragments, data types present in libraries, as well as any raml content present in yaml or json files.
+## Referencing external RAML content using `$ref`
+In order to support referencing RAML content in external files, AMF allows the use of the `$ref` mechanism present in Async.
+This enables referencing data type fragments, data types present in libraries, as well as any RAML content present in yaml or json files.
 
-Given that the payload content must comply with RAML, **the ‘$ref’ may only be used at the root of the payload definition as an exception to this rule**.
+However, the usage of `$ref` in this scenario has some restrictions. Given that the payload content must comply with RAML,
+**the `$ref` may only be used at the root of the payload definition as an exception to the RAML specification**.
 Its target content must be valid structurally according to the relevant RAML specification:
 
 export const myStyle = {
@@ -28,7 +29,7 @@ export const myStyle = {
 <div style={myStyle} className='col col--6'>
 
 ```yaml title="‘$ref’ at root of payload (Valid)"
-schemaFormat: application/raml+yaml;version=1.0
+schemaFormat: application/RAML+yaml;version=1.0
 payload:
   $ref: “...” # must reference raml content
 ```
@@ -36,7 +37,7 @@ payload:
 </div>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="‘$ref’ nested within raml content (Invalid)" {6}
+```yaml title="‘$ref’ nested within RAML content (Invalid)" {6}
 schemaFormat: application/raml+yaml;version=1.0
 payload:
  type: object
@@ -55,13 +56,13 @@ The following section shows all supported use cases when using this referencing 
 
 
 ### Reference to data type fragments
-The data type fragment must be self-contained, meaning it cannot depend on any definition made in the root api. The following example is **valid** for this use case.
+The data type fragment must be self-contained, meaning it cannot depend on any definition made in the root API. The following example is **valid** for this use case.
 
 <div className="container">
 <div className='row'>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="Async api"
+```yaml title="Async API"
 schemaFormat: application/raml+yaml;version=1.0
 payload:
  $ref: external-data-type.raml
@@ -82,14 +83,14 @@ properties:
 </div>
 </div>
 
-The following referenced data type is **invalid** as it is not self-contained, meaning the data type fragment depends on type definitions which will not be resolved in the root api.
-Due to known limitations this api will not return validations, but the reference to the type Other will not be made.
+The following referenced data type is **invalid** as it is not self-contained, meaning the data type fragment depends on type definitions which will not be resolved in the root API.
+Due to known limitations this API will not return any validations (error or warning), but the reference to the type `Other` inside the data type will not be made, leaving it unresolved.
 
 <div className="container">
 <div className='row'>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="Async api"
+```yaml title="Async API"
 components:
  schemas:
    Other: ...
@@ -136,7 +137,7 @@ This can be seen in the following **valid** example where the type User referenc
 <div className='row'>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="Async api"
+```yaml title="Async API"
 schemaFormat: application/raml+yaml;version=1.0
 payload:
   $ref: ../external-library.raml#/types/User
@@ -160,14 +161,14 @@ types:
 </div>
 </div>
 
-**The external library must be self-contained**, meaning it cannot depend on types defined in the root api.
-In the following **invalid** example, the library depends on the definition of the type Other, which will not be resolved from the definitions present in the main api.
+**The external library must be self-contained**, meaning it cannot depend on types defined in the root API.
+In the following **invalid** example, the library depends on the definition of the type Other, which will not be resolved from the definitions present in the main API.
 
 <div className="container">
 <div className='row'>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="Async api"
+```yaml title="Async API"
 components:
  schemas:
    Other: ...
@@ -202,7 +203,7 @@ When referencing external yaml or json files, the `$ref` inlines the content.
 Relative json pointers can be used to reference content that is nested within the file, but taking into account the following limitation:
 
 :::caution When referencing to external yaml/json files
-the external file **must not** be a known RAML fragment or api specification.
+the external file **must not** be a known RAML fragment or API specification.
 :::
 
 The following case is a **valid** reference making use of relative json pointers.
@@ -211,7 +212,7 @@ The following case is a **valid** reference making use of relative json pointers
 <div className='row'>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="Async api"
+```yaml title="Async API"
 schemaFormat: application/raml+yaml;version=1.0
 payload:
  $ref: external-yaml.yaml#/definitions/User
@@ -230,14 +231,14 @@ definitions:
 </div>
 </div>
 
-As previously mentioned, when the target file is a known raml fragment or api specification free use of relative json pointers is not supported.
+As previously mentioned, when the target file is a known RAML fragment or API specification free use of relative json pointers is not supported.
 The following example shows an **invalid** example when using relative json pointer to reference an external RAML specification:
 
 <div className="container">
 <div className='row'>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="Async api"
+```yaml title="Async API"
 schemaFormat: application/raml+yaml;version=1.0
 payload:
  $ref: ../api.raml#/types/User
@@ -246,7 +247,7 @@ payload:
 </div>
 <div style={myStyle} className='col col--6'>
 
-```yaml title="External RAML api (api.raml)" {1}
+```yaml title="External RAML API (api.raml)" {1}
 #%RAML 1.0
 title: Instagram API
 
@@ -262,7 +263,7 @@ types:
 
 
 ## Inlined RAML types
-The simplest way to define a raml type in Async is by defining your content inlined under the `payload` facet while using the appropriate schema format like so:
+The simplest way to define a RAML type in Async is by defining your content inlined under the `payload` facet while using the appropriate schema format like so:
 ```yaml
 schemaFormat: application/raml+yaml;version=1.0
 payload: # The following is a RAML data type
@@ -276,9 +277,9 @@ payload: # The following is a RAML data type
 
 ### Isolated RAML context
 When defining inlined types, its context is fully restricted from the content defined outside the payload facet.
-This means that any reference to content defined in the `components` facet of the main Async api will not be resolved.
+This means that any reference to content defined in the `components` facet of the main Async API will not be resolved.
 
-```yaml title="Referencing types defined in async api components (invalid)" {10}
+```yaml title="Referencing types defined in async API components (invalid)" {10}
 components:
  schemas:
    User: ...
@@ -294,8 +295,11 @@ channels:
 
 ### Limited RAML referencing mechanism
 RAML has its own referencing mechanism to include content from external files using a reserved yaml tag `!include`.
-**AMF will only support referencing external data type fragments when using this mechanism.** This feature will be limited to Async apis defined in yaml format, as json has no way of defining tags.
-As this syntax is valid within a RAML context, including data types fragments can be made at the root of the payload content, or nested within other inlined content:
+**AMF will only support referencing external data type fragments using the `!include` tag.**
+Furthermore, this will only work in Async APIs defined in yaml format, as json has no way of defining tags.
+
+As this syntax is valid within a RAML context, including data types fragments can be made at the root of the payload content,
+or nested within other inlined content:
 
 <div className="container">
 <div className='row'>

--- a/docs/related/json-schema-2019-to-draft-7.mdx
+++ b/docs/related/json-schema-2019-to-draft-7.mdx
@@ -12,7 +12,7 @@ This document is an analysis of which parts of Draft 2019-09 can be emitted as D
 The validators used by AMF have no short-term plans to support this draft.
 
 #### Background
-An initial support of Draft 2019-09 is necessary to start support of OpenApi 3.1. This support includes parsing, emission and validation.
+An initial support of Draft 2019-09 is necessary to start support of OpenAPI 3.1. This support includes parsing, emission and validation.
 The only aspect that is not owned by AMF is validation, which is delegated to Ajv for the JS Platform and Everit for JVM.
 
 These libraries won’t be supporting Draft 2019-09 in the short term so we need to workaround this.

--- a/docs/related/json-schema-2019-to-draft-7.mdx
+++ b/docs/related/json-schema-2019-to-draft-7.mdx
@@ -1,0 +1,249 @@
+---
+id: json_schema_draft_2019_09_to_draft_7
+title: Json Schema Draft 2019-09 to Draft 7 Emission
+---
+
+:::info Technical Document
+This is a technical document, this information is intended for experienced users
+:::
+
+#### Summary
+This document is an analysis of which parts of Draft 2019-09 can be emitted as Draft 7 to workaround existing lack of validation support for Draft 2019-09.
+The validators used by AMF have no short-term plans to support this draft.
+
+#### Background
+An initial support of Draft 2019-09 is necessary to start support of OpenApi 3.1. This support includes parsing, emission and validation.
+The only aspect that is not owned by AMF is validation, which is delegated to Ajv for the JS Platform and Everit for JVM.
+
+These libraries won’t be supporting Draft 2019-09 in the short term so we need to workaround this.
+As we already re-emit parsed Json Schemas to validate them, we want to assess the possibility of cross-emitting Draft 2019-09 to Draft 7 to take advantage of the current supported drafts.
+
+
+## Related aspects
+
+### Error messages
+Translating Draft 2019-09 into Draft 7 will affect error messages as the schema path in the error will be different from the original. For example:
+
+export const myStyle = {
+    padding: "15px 5px",
+};
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```json title="Draft 2019-09"
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "credit_card": { "type": "number" },
+    "bank_number": { "type": "number"}
+  },
+  "required": ["name"],
+  "dependentSchemas": {
+    "credit_card": {
+      "properties": {
+        "billing_address": { "type": "string" }
+      },
+      "required": ["billing_address"]
+    }
+  },
+  "dependentRequired": {
+    "bank_number": ["credit_card"]
+  }
+}
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```json title="Draft 7"
+{
+   "$schema": "https://json-schema.org/draft/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "credit_card": { "type": "number" },
+    "bank_number": { "type": "number"}
+  },
+  "required": ["name"],
+  "dependencies": {
+    "credit_card": {
+      "properties": {
+        "billing_address": { "type": "string" }
+      },
+      "required": ["billing_address"]
+    },
+    "bank_number": ["credit_card"]
+  }
+}
+```
+
+</div>
+</div>
+</div>
+
+
+These semantically equal schemas are written differently according to the draft version. They both define two dependencies,
+one is a subschema and the other is a boolean array. The only difference is the error message they will produce **if** the schema path is present.
+
+On validating the following example, we can see that the `billing_address` key is missing:
+
+```json
+{
+  "name": "Someone",
+  "bank_number": 4,
+  "credit_card": 5
+}
+```
+
+The schema paths of each error are:
+- Draft 2019-09: `#/dependentSchemas/credit_card/required`
+- Draft 7: `#/dependencies/credit_card/required.`
+
+
+
+### Untranslatable keywords
+there are some Draft 2019-09 keywords that cannot be ported to Draft 7 as they are entirely new concepts.
+We should decide the expected behaviour if a user tries to validate a payload against a Draft 2019-09 parsed schema. There are several options:
+
+- **Warning or violation when validating**
+    - We could issue a warning or violation when we detect that a schema parsed from Draft 2019-09 is used.
+    To do this we would have to traverse the schema and detect for specific model attributes. This will add processing time to validation.
+
+- **Warning or violation when parsing**
+    - We could emit a warning or violation when parsing. This is efficient as we only have to detect a Draft 2019-09 specific keyword, something that is necessary for parsing.
+    - The downside is that the “parsing module” fully supports Draft 2019-09, it doesn't make sense to specify a “validation rule” on the “parsing module”.
+
+- **Only add it to Release Notes**
+    - The third option is to only add it in the Release Notes and nothing else. Each consumer will be able to handle it as it likes without AMF imposing specific feedback.
+
+All the considered options have to be **backward compatible**.
+
+
+## Proposed translations
+#### Remove `format` keyword OR turn off format validations if possible
+In Draft 2019-09 format validations are turned off. We should respect this in Draft 7 and do one of two:
+- Remove `format` keywords on schema emission to avoid the validation.
+- Turn off “format” validations in Ajv and Everit. Ajv seems to be the only one that has it well documented.
+Another thing to test is how the “format” value is validated (if it is limited to a possible set of values by the validator)
+
+#### Change `$defs` for `definitions`
+A really straight-forward change.
+
+#### `$ref` keyword will be emitted as `allOf`
+In Json Schema 2019-09 the `$ref` keyword can now be alongside other keywords, but we can’t lose the surrounding, same-level information (that is not taken into account when a `$ref` is found).
+According to several parts in the Json Schema issues, the following transformation should be valid for our use case:
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```json title="Draft 2019-09"
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "$ref": "#/definitions/somewhere"
+}
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```json title="Draft 7"
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/somewhere"
+    }
+  ]
+}
+```
+
+</div>
+</div>
+</div>
+
+If the schema already has an `allOf`, the `$ref` will simply be appended to it. An annotation will need to be added to signal that it is a top level schema.
+
+#### Unify `dependentSchemas` and `dependentRequired` into `dependencies`
+These Draft 2019-09 facets should be unified in Draft 7. For example:
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```json title="Draft 2019-09"
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "credit_card": { "type": "number" },
+    "bank_number": { "type": "number"}
+  },
+  "required": ["name"],
+  "dependentSchemas": {
+    "credit_card": {
+      "properties": {
+        "billing_address": { "type": "string" }
+      },
+      "required": ["billing_address"]
+    }
+  },
+  "dependentRequired": {
+    "bank_number": ["credit_card"]
+  }
+}
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```json title="Draft 7"
+{
+  "$schema": "https://json-schema.org/draft/draft-07/schema",
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "credit_card": { "type": "number" },
+    "bank_number": { "type": "number"}
+  },
+  "required": ["name"],
+  "dependencies": {
+    "credit_card": {
+      "properties": {
+        "billing_address": { "type": "string" }
+      },
+      "required": ["billing_address"]
+    },
+    "bank_number": ["credit_card"]
+  }
+}
+```
+
+</div>
+</div>
+</div>
+
+
+#### Unsupported properties
+The following properties will not be translated into Draft 2019-09 as there is no possible construct in Draft 7:
+- `unevaluatedProperties` and `unevaluatedItems`
+- `minContains` and `maxContains`
+- `contentSchema`
+
+Warnings will be added if one of the above fields exist when emitting another Draft that isn’t 2019.
+The only exception will be `contentSchema` that won’t be validated as the spec says it is a SHOULD.

--- a/docs/templates/templates.mdx
+++ b/docs/templates/templates.mdx
@@ -1,0 +1,62 @@
+# Code examples side-by-side
+NOTE: don't listen to intellij formatting and use this exact tab order or else the parser can't read the markdown inside the jsx,
+use copy and then `paste as plain text`.
+
+export const myStyle = {
+    padding: "15px 5px",
+};
+
+<div className="container">
+<div className='row'>
+<div style={myStyle} className='col col--6'>
+
+```java title="example" {1}
+// code example
+// more code
+```
+
+</div>
+<div style={myStyle} className='col col--6'>
+
+```java title="example" {1}
+// code highlighted
+// more code
+```
+
+</div>
+</div>
+</div>
+
+
+
+
+# Multiple code tabs
+NOTE: the code tabs should have exactly this indentation, where the `TabItem` are at the same level as the `Tabs`
+Supports groupId for saving user selection and uses CodeGetter to fetch each example from GitHub:
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import CodeGetter from "../../components/CodeGetter";
+
+<Tabs
+    groupId="languages"
+    defaultValue="java"
+    values={[
+        {label: 'Java', value: 'java'},
+        {label: 'JavaScript', value: 'js'}
+    ]}
+>
+
+<TabItem value="java">
+    <CodeGetter
+        language='java'
+        codeUrl='examples/master/src/main/java/aml_org/examples/Parsing.java'
+    />
+</TabItem>
+<TabItem value="js">
+    <CodeGetter
+        language='js'
+        codeUrl='examples/master/src/main/js/Parsing.js'
+    />
+</TabItem>
+</Tabs>

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -22,6 +22,11 @@ module.exports = {
             'aml',
             'aml_spec',
             'aml_validation_model'
+        ],
+        'Related Docs': [
+            'related/amf_conversion',
+            'related/async_raml_datatypes',
+            'related/json_schema_draft_2019_09_to_draft_7'
         ]
     }
 };

--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -57,3 +57,15 @@ html[data-theme='dark'] .header-npm-link:before {
 .prism-code {
     max-height: 600px;
 }
+
+.docusaurus-highlight-code-line {
+    background-color: rgb(255, 187, 187);
+    display: block;
+    margin: 0 calc(-1 * var(--ifm-pre-padding));
+    padding: 0 var(--ifm-pre-padding);
+}
+
+/* If you have a different syntax highlighting theme for dark mode. */
+html[data-theme='dark'] .docusaurus-highlight-code-line {
+    background-color: rgb(255, 123, 123); /* Color which works with dark mode syntax highlighting theme */
+}

--- a/website/src/pages/old-index.js
+++ b/website/src/pages/old-index.js
@@ -106,13 +106,6 @@ function Home() {
                 </section>
                 <section>
                     <div className="container">
-                        {/*<div className='row'>*/}
-                        {/*    <div className='col'>*/}
-                        {/*        <h2 className='text--center' style={{ fontSize: '2.5rem' }}>*/}
-                        {/*            See it in action*/}
-                        {/*        </h2>*/}
-                        {/*    </div>*/}
-                        {/*</div>*/}
                         <div className='row'>
                             <div className='col col--6'>
                                 <div className='code'>


### PR DESCRIPTION
Added the following AMF technical documents:
- Conversion document.
- Async RAML types document.
- JSON Schema 2019 to schema07 emission document.

Also added `templated.mdx` with multiple examples for code styling, comparing and highlighting.