### PR TITLE
APIMF-3029: update docusaurus to .73 version

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,7 +56,7 @@ module.exports = {
                     position: 'left'
                 },
                 {
-                    to: 'docs/AMF/amf_intro',
+                    to: 'docs',
                     label: 'AMF',
                     position: 'left'
                 },

--- a/website/package.json
+++ b/website/package.json
@@ -13,8 +13,8 @@
     "docusaurus": "docusaurus"
   },
   "dependencies": {
-    "@docusaurus/core": "2.0.0-alpha.70",
-    "@docusaurus/preset-classic": "2.0.0-alpha.70",
+    "@docusaurus/core": "2.0.0-alpha.73",
+    "@docusaurus/preset-classic": "2.0.0-alpha.73",
     "@monaco-editor/react": "^3.7.3",
     "bootstrap": "^4.5.3",
     "classnames": "^2.2.6",


### PR DESCRIPTION
updated docusaurus to latest version, should fix dependabot alerts and PRs. I've also fixed some docs URLs to improve indexing and reduce broken links.