### PR TITLE
Fix windows relative path example

### DIFF
--- a/docs/AMF/using-amf/parsing.mdx
+++ b/docs/AMF/using-amf/parsing.mdx
@@ -41,7 +41,7 @@ The file paths you give the parser must have the following structure:
 
 Windows:
 - Absolute path: `file:///C:/testing/api.raml`
-- Relative path: `file:///api.raml`
+- Relative path: `file://api.raml`
 
 MacOS and Unix:
 - Absolute path: `file:///Users/aml/testing/api.raml`


### PR DESCRIPTION
Fix windows relative path example